### PR TITLE
Terminal display now shows full path to file instead of just file name.

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -156,7 +156,7 @@ bool NDFile::readFile(String path) {
   }
   vgm.size = _vgmFile.size();
   _vgmFile.read(vgm.vgmData, vgm.size);
-  Serial.printf("File name: %s\n", _vgmFile.name());
+  Serial.printf("File name: %s\n", _vgmFile.path());
   _vgmFile.close();
 
   // check file


### PR DESCRIPTION
Many file names could be the same or not have enough have context, this shows the full path so you can more easily tell what is being played from the serial / terminal console.